### PR TITLE
Callgraph-based approach of coverage analysis in fuzz testing.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,9 @@ install:
     - make install
 
 before_script:
-    - sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-4.9 90
-    - sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-4.9 90
+    - sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-9 90
+    - sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-9 90
+    - sudo update-alternatives --install /usr/bin/gcov gcov /usr/bin/gcov-9 90
     - sudo apt-get install -y clang-3.5
 
 script:
@@ -26,8 +27,11 @@ addons:
     sources:
       - ubuntu-toolchain-r-test
     packages:
+      - cflow
       - g++-4.9
       - gcc-4.9
+      - g++-9
+      - gcc-9
       - time
       - libunwind8-dev
 

--- a/perun/cli.py
+++ b/perun/cli.py
@@ -643,6 +643,10 @@ def collect(ctx, **kwargs):
 @click.option('--gcno-path', '-g', nargs=1, required=False,
               type=click.Path(exists=True, writable=True), metavar='<path>',
               help='The path to the directory where .gcno files are stored.')
+@click.option('--gcov-path', '-d', nargs=1, required=False,
+              type=click.Path(exists=True, writable=True), metavar='<path>',
+              help='The path to the directory where building of project is launched'
+              ' (usually where Makefile is located).')
 @click.option('--output-dir', '-o', nargs=1, required=True,
               type=click.Path(exists=True, writable=True), metavar='<path>',
               help='The path to the directory where generated outputs will be stored.')
@@ -689,6 +693,10 @@ def collect(ctx, **kwargs):
               ' written in YAML format file.')
 @click.option('--no-plotting', '-np', is_flag=True, required=False,
               help='Avoiding sometimes lengthy plotting of graphs.')
+@click.option('--new-approach', '-na', is_flag=True, required=False,
+              help='New callgraph unique paths coverage approach.')
+
+
 def fuzz_cmd(cmd, args, **kwargs):
     """Performs fuzzing for the specified command according to the initial sample of workload."""
     kwargs['executable'] = Executable(cmd, args)

--- a/perun/fuzz/callgraph.py
+++ b/perun/fuzz/callgraph.py
@@ -1,0 +1,49 @@
+"""Module used for our representation of callgraph using `angr` framework."""
+
+__author__ = 'Matus Liscinsky'
+
+import angr
+import matplotlib.pyplot as plt
+import numpy as np
+
+import perun.fuzz.structs as structs
+import perun.utils.log as log
+from perun.fuzz.evaluate.by_coverage import get_src_files
+
+
+def initialize(executable, source_path):
+    """Creates callgraph of the target application.
+
+    It uses `angr` to obtain CFG of the target application, then it goes from the main function
+    throughout the functions in CFG in order to build a static callgraph. At the end, it identifies
+    functions from system libraries, which is important for further work with the exclusive coverage
+    information of these functions.
+
+    :param Executable executable: executable profiled command
+    :param str source_path: path to the directory, where source codes are stored
+    :return CallGraph: struct of the target application callgraph
+    """
+    log.info("Generating CFG (angr) ")
+
+    # Creating project object
+    proj = angr.Project(executable.cmd, load_options={'auto_load_libs': False})
+
+    # Obtaining Control-Flow-Graph
+    cfg = proj.analyses.CFGFast(normalize=True)
+
+    # Main function
+    main_obj = proj.loader.main_object.get_symbol("main")
+    main_func = cfg.kb.functions[main_obj.rebased_addr]
+
+    log.done()
+    log.info("Extracting information to create callgraph ", end='')
+
+    # Building and filling our callgraph representation
+    cg = structs.CallGraph(main_func, proj.kb)
+
+    # Search for functions from system libraries
+    src_files = get_src_files(source_path)
+    cg.identify_lib_functions(src_files)
+
+    log.done()
+    return cg

--- a/perun/fuzz/evaluate/by_coverage.py
+++ b/perun/fuzz/evaluate/by_coverage.py
@@ -261,9 +261,9 @@ def get_vectors_from_gcov_JSON(json_gcov_data, callgraph):
     inclusive_execs = dict()
     exclusive_execs = dict()
     try:
-        cwd = json_gcov_data['current_working_directory'] + "/"
+        cwd = json_gcov_data['current_working_directory']
         for file in json_gcov_data['files']:
-            file_path = cwd + file["file"]
+            file_path = path.join(cwd, file["file"])
             # counts executed lines in functions (INCLUSIVE coverage),
             # and also system library function calls (EXCLUSIVE coverage)
             for line in file['lines']:

--- a/perun/fuzz/factory.py
+++ b/perun/fuzz/factory.py
@@ -379,13 +379,15 @@ def teardown(fuzz_progress, output_dirs, parents, rule_set, config):
         log.info("Plotting time series of fuzzing process...")
         interpret.plot_fuzz_time_series(
             fuzz_progress.deg_time_series,
-            output_dirs["graphs"] + "/" + fuzz_progress.start_timestamp + "_degradations_ts.pdf",
+            path.join(
+                output_dirs["graphs"], fuzz_progress.start_timestamp + "_degradations_ts.pdf"),
             "Fuzzing in time", "time (s)", "degradations"
         )
         if config.coverage_testing:
             interpret.plot_fuzz_time_series(
                 fuzz_progress.cov_time_series,
-                output_dirs["graphs"] + "/" + fuzz_progress.start_timestamp + "_coverage_ts.pdf",
+                path.join(
+                    output_dirs["graphs"], fuzz_progress.start_timestamp + "_coverage_ts.pdf"),
                 "Max path during fuzing", "time (s)", "executed lines ratio"
             )
     # Plot the differences between seeds and inferred mutation
@@ -505,7 +507,7 @@ def run_fuzzing_for_command(executable, input_sample, collector, postprocessor, 
     # No gcno files were found, no coverage testing
     if not fuzz_progress.base_cov:
         # avoiding possible further zero division
-        fuzz_progress.base_cov = Coverage([],[]) if config.new_approach else 1
+        fuzz_progress.base_cov = Coverage([], []) if config.new_approach else 1
         config.coverage_testing = False
         log.warn("No .gcno files were found.")
 

--- a/perun/fuzz/filesystem.py
+++ b/perun/fuzz/filesystem.py
@@ -73,13 +73,15 @@ def del_temp_files(parents, fuzz_progress, output_dir):
     :param FuzzingProgress fuzz_progress: progress of the fuzzing
     :param str output_dir: path to directory, where fuzzed files are stored
     """
-    log.info("Removing remaining mutations", end='')
+    log.info("Removing remaining mutations ", end='')
     for mutation in parents:
         if mutation not in fuzz_progress.final_results and mutation not in fuzz_progress.hangs \
                 and mutation not in fuzz_progress.faults and \
                 mutation.path.startswith(output_dir) and path.isfile(mutation.path):
+            # for evaluation purposes only:
+            # don't remove the best mutation in case that no degradative mutation has been found
+            # and mutation.path != fuzz_progress.parents[-1].path
             with helpers.SuppressedExceptions(FileNotFoundError):
                 os.remove(mutation.path)
-                log.info('.')
-        log.info('-')
+            log.info('-', end="")
     log.done()

--- a/perun/fuzz/helpers.py
+++ b/perun/fuzz/helpers.py
@@ -1,6 +1,51 @@
 """Collection of helper functions used in fuzzing"""
 
-__author__ = 'Tomas Fiedor'
+__author__ = 'Tomas Fiedor, Matus Liscinsky'
+
+import numpy as np
+
+from perun.postprocess.regression_analysis.tools import APPROX_ZERO
+
+
+def median_vector(vectors):
+    """Computes piecewise median from list of numerical vectors.
+
+    :param list vectors: list of vectors (lists with numerical value)
+    :return list: vector, which has on each position median value from all vectors on this postition
+    """
+    data = np.array(vectors)
+    data = data.astype('float')
+    data[data == 0.0] = APPROX_ZERO
+    return (np.median(data,axis=0)).tolist()
+
+
+def sum_vectors_piecewise(vec1, vec2):
+    """Creates a vector, where each value on position i is sum of vec1[i] and vec2[i]. Lengths of the
+        vectors does not have to equal.
+
+    :param list vec1: first vector
+    :param list vec2: second vector
+    :return list: [vec1[0]+vec2[0], vec1[1]+vec2[1], ...]
+    """
+    # fill in 0 so that the lengths of the vectors are equal (0 is a neutral element for addition)
+    if len(vec1) != len(vec2):
+        shorter_list = min(vec1, vec2, key=len)
+        diff = abs(len(vec1) - len(vec2))
+        shorter_list.extend([0]*diff)
+    # numpy array automatically sums element-wise
+    return (np.array(vec1) + np.array(vec2)).tolist()
+
+
+def div_vectors_piecewise(vec1, vec2):
+    """Creates a vector, where each value on position i is div of vec1[i] by vec2[i]. Lengths of the
+        vectors have to equal.
+
+    :param list vec1: first vector
+    :param list vec2: second vector
+    :return list: [vec1[0]/vec2[0], vec1[1]/vec2[1], ...] or empty list if the lengths don't equal
+    """
+    # numpy array automatically divs element-wise
+    return (np.array(vec1)/ np.array(vec2)).tolist() if len(vec1) == len(vec2) else []
 
 
 def insert_at_split(lines, index, split_position, inserted_bytes):

--- a/perun/fuzz/interpret.py
+++ b/perun/fuzz/interpret.py
@@ -70,11 +70,11 @@ def save_log_files(log_dir, fuzz_progress):
     """
     log.info("Saving log files ", end="")
     deg_data_file = open(
-        log_dir + "/" + fuzz_progress.start_timestamp + "_degradation_plot_data.txt", "w")
+        path.join(log_dir, fuzz_progress.start_timestamp + "_degradation_plot_data.txt"), "w")
     cov_data_file = open(
-        log_dir + "/" + fuzz_progress.start_timestamp + "_coverage_plot_data.txt", "w")
+        path.join(log_dir, fuzz_progress.start_timestamp + "_coverage_plot_data.txt"), "w")
     results_data_file = open(
-        log_dir + "/" + fuzz_progress.start_timestamp + "_results_data.txt", "w")
+        path.join(log_dir, fuzz_progress.start_timestamp + "_results_data.txt"), "w")
 
     save_time_series(deg_data_file, fuzz_progress.deg_time_series)
     save_time_series(cov_data_file, fuzz_progress.cov_time_series)
@@ -257,9 +257,9 @@ def draw_paths_heatmap(callgraph, graphs_dir, fuzzing_timestamp):
     mask = ([False]*path_count) + ([True]*empty_cells)
 
     # Transform each list to 2d array (matrix)
-    data_inc = [data_inc[i:i+cols] for i in range(0, len(data_inc), cols)]
-    data_exc = [data_exc[i:i+cols] for i in range(0, len(data_exc), cols)]
-    mask = [mask[i:i+cols] for i in range(0, len(mask), cols)]
+    data_inc = np.array(data_inc).reshape((rows,cols))
+    data_exc = np.array(data_exc).reshape((rows,cols))
+    mask = np.array(mask).reshape((rows,cols))
 
     sns.set()
     log.info("Plotting heatmaps of callgpaph paths coverage.", end="")

--- a/perun/fuzz/structs.py
+++ b/perun/fuzz/structs.py
@@ -120,7 +120,8 @@ class FuzzingConfiguration:
                                  kwargs.get("gcno_path") and
                                  kwargs.get("gcov_path")) is not None
         self.coverage = CoverageConfiguration(**kwargs)
-        self.new_approach = self.coverage_testing and kwargs['new_approach']
+        self.new_approach = self.coverage_testing and kwargs['new_approach'] and \
+            self.coverage.gcov_version >= GCOV_VERSION_W_JSON_FORMAT
 
     RATIO_INCR_CONST = 0.05
     RATIO_DECR_CONST = 0.01

--- a/perun/fuzz/structs.py
+++ b/perun/fuzz/structs.py
@@ -1,9 +1,18 @@
-"""Collection of helpers structures for fuzzing"""
+"""Collction of helpers structures for fuzzing"""
 
+import copy
 import os
+import time
 from collections import namedtuple
 
-__author__ = 'Tomas Fiedor'
+import numpy as np
+from angr.codenode import BlockNode, HookNode
+
+# for cross-reference table using cflow
+from perun.fuzz.evaluate.by_coverage import (GCOV_VERSION_W_JSON_FORMAT, compute_vectors_score,
+                                             execute_bin, get_gcov_version, Coverage)
+
+__author__ = 'Tomas Fiedor, Matus Liscinsky'
 
 
 TimeSeries = namedtuple("TimeSeries", "x_axis y_axis")
@@ -19,6 +28,7 @@ class Mutation:
     :ivar int deg_ratio: achieved degradation ration
     :ivar float fitness: fitness of the mutation
     """
+
     def __init__(self, path, history, predecessor, cov=0, deg_ratio=0, fitness=0):
         """
         :param str path: path to the workload
@@ -41,19 +51,24 @@ class CoverageConfiguration:
 
     :ivar str gcno_path: path to the directory, where .gcno files are stored
     :ivar str source_path: path to the directory, where source codes are stored
+    :ivar str gcov_path: path to the directory, where building was executed and gcov should be too
     :ivar int gcov_version: version of the gcov utility
     :ivar list gcov_files: list of gcov files
     :ivar list source_files: list of source files
+    :ivar CallGraph callgraph: struct of the target application callgraph
     """
+
     def __init__(self, **kwargs):
         """
         :param dict kwargs: set of keyword configurations
         """
         self.gcno_path = kwargs['gcno_path']
         self.source_path = kwargs['source_path']
-        self.gcov_version = None
+        self.gcov_path = kwargs['gcov_path']
+        self.gcov_version = get_gcov_version()
         self.gcov_files = []
         self.source_files = []
+        self.callgraph = None
 
 
 class FuzzingConfiguration:
@@ -80,7 +95,10 @@ class FuzzingConfiguration:
     :ivar bool coverage_testing: specifies if the mutations should be tested for coverage also,
         or only using perun
     :ivar CoverageConfiguration coverage
+    :ivar bool new_approach: variable denoting if we work with the static callgraph (True) in
+        coverage analysis
     """
+
     def __init__(self, **kwargs):
         """
         :param dict kwargs: set of keyword configurations
@@ -98,8 +116,11 @@ class FuzzingConfiguration:
         self.mutations_per_rule = kwargs["mutations_per_rule"]
         self.no_plotting = kwargs['no_plotting']
         self.cov_rate = kwargs['coverage_increase_rate']
-        self.coverage_testing = (kwargs.get("source_path") and kwargs.get("gcno_path")) is not None
+        self.coverage_testing = (kwargs.get("source_path") and
+                                 kwargs.get("gcno_path") and
+                                 kwargs.get("gcov_path")) is not None
         self.coverage = CoverageConfiguration(**kwargs)
+        self.new_approach = self.coverage_testing and kwargs['new_approach']
 
     RATIO_INCR_CONST = 0.05
     RATIO_DECR_CONST = 0.01
@@ -123,24 +144,32 @@ class FuzzingProgress:
     :ivar list interesting_workloads: list of potentially interesting workloads
     :ivar list parents: list of fitness values for parents
     :ivar list final_results: list of final results
-    :ivar int timeout: timeout of the fuzzing
     :ivar dict stats: additional stats of fuzz testing
+    :ivar str start_timestamp: datetime information about the start of fuzzing
     """
-    def __init__(self):
+
+    def __init__(self, config):
         """
-        :param int timeout: timeout for the fuzzing
+        :param FuzzingConfiguration config: configuration of the fuzzing
         """
         self.faults = []
         self.hangs = []
         self.interesting_workloads = []
         self.parents = []
         self.final_results = []
+        self.start_timestamp = time.strftime(
+            "%Y-%m-%d-%H-%M-%S", time.localtime())
 
         # Time series plotting
         self.deg_time_series = TimeSeries([0], [0])
         self.cov_time_series = TimeSeries([0], [1.0])
 
         self.base_cov = 1
+        if config.coverage_testing:
+            if config.new_approach and config.coverage.gcov_version is not None and \
+               config.coverage.gcov_version >= GCOV_VERSION_W_JSON_FORMAT:
+                # new approach is used only when JSON gcov output is available
+                self.base_cov = Coverage([], [])
 
         self.stats = {
             "start_time": 0.0,
@@ -154,6 +183,283 @@ class FuzzingProgress:
             "faults": 0
         }
 
-    def update_max_coverage(self):
-        """Updates the maximal achieved coverage according to the parent fitness values"""
-        self.stats["max_cov"] = self.parents[-1].cov / self.base_cov
+    def update_max_coverage(self, new_approach):
+        """Updates the maximal achieved coverage according to the parent fitness values
+
+        :param bool new_approach: variable denoting if we work with the static callgraph (True) in
+        coverage analysis
+        """
+        self.stats["max_cov"] = compute_vectors_score(
+            self.parents[-1], self) if new_approach else self.parents[-1].cov / self.base_cov
+
+
+class CallGraph:
+    """Struct representing static callgraph of the target application.
+
+    :ivar dict functions: dictionary of callgraph functions
+    :ivar list _unique_paths: list of all unique paths from the root function all leaf nodes
+    :ivar list _current_path: curren chain of functions in the process of building the callgraph
+    :ivar Function root: main function of the CFG generated by the `angr` framework
+        (this Function is `angr` class)
+    :ivar dict references: mapping of source code lines to calls of the functions
+    :ivar list path_effectivity: success of unique paths
+        (how many times coverage of the certain path has sufficiently raised)
+    """
+
+    def __init__(self, root, kb):
+        """
+        :param root: main function of the CFG generated by the `angr` framework
+        :param kb: knowledge base of the project object
+        """
+        self.functions = dict()
+        self._unique_paths = []
+        self._current_path = Path()
+        self.root = self.create(root, kb)
+        self.references = dict()
+        self.path_effectivity = [0]*len(self._unique_paths)
+
+    def create(self, root, kb):
+        """Recursive function that creates callgraph.
+
+        :param root: main function of the CFG generated by the `angr` framework
+        :param kb: knowledge base of the project object
+        :return CallGraph : struct of the target application callgraph
+        """
+        if isinstance(root, BlockNode):
+            return None
+        elif isinstance(root, HookNode):
+            # leaves
+            if root.addr in kb.functions:
+                hook_function = kb.functions[root.addr]
+                new_root = Function(hook_function.name, hook_function.addr)
+                new_root.leaf_node = True
+
+                self._current_path.append_function(new_root)
+                self.functions[new_root.name] = new_root
+                self._unique_paths.append(Path.from_path(self._current_path))
+                self._current_path.pop_function()
+                return new_root
+            return None
+        else:
+            # it's a function
+            # check if its in the path already, if true, it is a recursive function
+            if self._current_path.contains_funtion(root):
+                self.functions[root.name].recursive = True
+                return root
+            # already processed function (function doesn't have to be in the current path, but can be already processed)
+            if root.name in self.functions:
+                return None
+            # else, not recursive and not processed function
+            else:
+                new_root = Function(root.name, root.addr)
+                self.functions[new_root.name] = new_root
+            self._current_path.append_function(new_root)
+
+            for fun in root.nodes:
+                if fun.addr == root.addr and not isinstance(fun, BlockNode):
+                    if not isinstance(fun, HookNode):
+                        new_root.recursive = True
+                    continue
+                subtree_root = self.create(fun, kb)
+                # this function was seen
+                if subtree_root == fun:
+                    new_root.leaf_node = True
+                    self._unique_paths.append(
+                        Path.from_path(self._current_path))
+                # note: subtree can be None in case of BlockNode in CFG
+                elif subtree_root:
+                    new_root.add_node(subtree_root)
+            if not new_root.nodes:
+                self._unique_paths.append(Path.from_path(self._current_path))
+            self._current_path.pop_function()
+            return new_root
+
+    def identify_lib_functions(self, source_files):
+        """Uses cflow utility in order to find system library function calls and label
+            these functions.
+
+        :param list source_files: list of source file's paths
+        """
+        user_defined_functions = []
+        command = ["cflow", "-x"]
+        command.extend(source_files)
+        output = execute_bin(command)
+        for func_call in output["output"].split("\n"):
+            if not func_call:  # note that empty string is at the end of output
+                continue
+            func_name = func_call.split(
+            )[0] if func_call.split() else ""  # function name
+            if func_name in user_defined_functions:
+                continue
+            elif "*" in func_call:
+                user_defined_functions.append(func_name)
+                continue
+            else:
+                try:
+                    function_obj = self.functions[func_name]
+                    function_obj.is_lib = True
+                    self.add_reference((func_call.split()[-1]), function_obj)
+                except KeyError:
+                    pass
+
+    def add_reference(self, location, obj):
+        """Adds reference of the function in the references dictionary.
+
+        :param str location: path of the source file followed by the ':' and a line number
+        :param Function obj: function object of the function called in the @p location
+        """
+        if self.references:
+            try:
+                self.references[location].append(obj)
+            except KeyError:
+                self.references.update([(location, [obj])])
+        else:
+            self.references = {location: [obj]}
+
+    def update_paths_effectivity(self, paths_results, inc_coverage_increase, exc_coverage_increase):
+        """Updates the effectivity of the callgraph unique paths, plus updates their max reached
+            coverage ratio.
+
+        :param tuple paths_results: zipped results of comparisions with baseline and parent workload
+        :param list inc_coverage_increase: inclusive coverage increase of the paths
+        :param list exc_coverage_increase: exclusive coverage increase of the paths
+        """
+        for i, (cmp_with_baseline_inc, cmp_with_baseline_exc,
+                cmp_with_parent_inc, cmp_with_parent_exc) in enumerate(paths_results):
+            if cmp_with_baseline_inc and cmp_with_parent_inc or cmp_with_baseline_exc and cmp_with_parent_exc:
+                self.path_effectivity[i] += 1
+                self._unique_paths[i].effectivity += 1
+            self._unique_paths[i].update_max_cov(
+                inc_coverage_increase[i],
+                exc_coverage_increase[i]
+            )
+
+
+class Function:
+    """Class that represents callgraph node --- function.
+
+    :ivar str name: name of the function
+    :ivar int addr: address of the function
+    :ivar list nodes: descendants of the function in the callgraph
+    :ivar list parents: parents of the function in the callgraph
+    :ivar bool recursive: variable denoting whether the function is recursive
+    :ivar bool leaf_node: variable denoting whether the node is a leaf in the callgraph
+    :ivar bool is_lib: variable denoting whether the function is from system libraries
+    :ivar dict references: dictionary of the function calls
+    """
+
+    def __init__(self, name, addr, nodes=[], parents=[]):
+        """
+
+        :param name: name of the function
+        :param addr: address of the function
+        :param nodes: descendants of the function in the callgraph, defaults to []
+        :param parents: parents of the function in the callgraph, defaults to []
+        """
+        self.name = name
+        self.addr = addr
+        self.nodes = nodes
+        self.parents = parents
+        self.recursive = False
+        self.leaf_node = False
+        # for lib functions
+        self.is_lib = False
+
+    def add_node(self, node):
+        """Adds node to the function descendands.
+
+        :param Function node: function/node to be added
+        """
+        if self.nodes:
+            self.nodes.append(node)
+        else:
+            self.nodes = [node]
+
+    # def to_string(self):
+    #     """Function for debugging purposes only.
+    #     """
+    #     print(self.name, self.addr, "recursive:", self.recursive,
+    #           "leaf_node:", self.leaf_node, "nodes:", len(self.nodes))
+
+
+class Path:
+    """Class representing a path in the callgraph.
+    :ivar list func_chain: chain of functions
+    :ivar int effectivity: the effectivity of the path
+    :ivar float max_inc_cov_increase: maximum increase in inclusive coverage of the path
+        during fuzzing
+    :ivar float max_exc_cov_increase: maximum increase in exclusive coverage of the path
+        during fuzzing
+    """
+
+    def __init__(self, func_chain=None, effectivity=0, max_inc_cov_increase=1.0, max_exc_cov_increase=1.0):
+        """
+        :ivar list func_chain: chain of functions
+        :ivar int effectivity: the effectivity of the path
+        :ivar float max_inc_cov_increase: maximum increase in inclusive coverage of the path
+            during fuzzing
+        :ivar float max_exc_cov_increase: maximum increase in exclusive coverage of the path
+            during fuzzing
+        """
+        self.func_chain = func_chain if func_chain else []
+        self.effectivity = effectivity
+        self.max_inc_cov_increase = max_inc_cov_increase
+        self.max_exc_cov_increase = max_exc_cov_increase
+
+    # copy constructor
+    @classmethod
+    def from_path(Path, path_instance):
+        """Function is a copy constructor of Path.
+
+        :param path_instance: instance of the path to be copied
+        :return Path: new Path instance
+        """
+        # deepcopy
+        func_chain = copy.deepcopy(
+            path_instance.func_chain)
+        return Path(
+            func_chain, path_instance.effectivity,
+            path_instance.max_inc_cov_increase, path_instance.max_exc_cov_increase)
+
+    def update_max_cov(self, inc_cov_incr, exc_cov_incr):
+        """Updates max reached coverages.
+
+        :param inc_cov_incr: reached inclusive coverage increase
+        :param exc_cov_incr: reached exclusive coverage increase
+        """
+        self.max_inc_cov_increase = max(
+            self.max_inc_cov_increase, inc_cov_incr)
+        self.max_exc_cov_increase = max(
+            self.max_exc_cov_increase, exc_cov_incr)
+
+    def contains_funtion(self, function):
+        """Decides whether the function is already in the function chain.
+
+        :param function: object of `angr` function, which address we looking for in the chain
+        :return bool: True if the function is in the function chain, False otherwise
+        """
+        # note: here, function is an instance of angr function class
+        for fun in self.func_chain:
+            if fun.addr == function.addr:
+                return True
+        return False
+
+    def append_function(self, function):
+        """Appends function at the end of the function chain.
+
+        :param Function function: function to be appended
+        """
+        # note: here, function is an instance of our function class
+        self.func_chain.append(function)
+
+    def pop_function(self):
+        """Pops function from the end of the function chain.
+        """
+        self.func_chain.pop()
+
+    def to_string(self):
+        """Function that converts function chain into formatted string.
+
+        :return: formatted string from a Path object
+        """
+        return "->".join([func.name for func in self.func_chain])

--- a/requirements.txt
+++ b/requirements.txt
@@ -27,4 +27,5 @@ matplotlib==1.5.1
 binaryornot==0.4.4
 tabulate==0.8.6
 pip==8.1.1
-angr>=8.19.7.25
+angr==8.19.7.25
+seaborn==0.9.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -27,3 +27,4 @@ matplotlib==1.5.1
 binaryornot==0.4.4
 tabulate==0.8.6
 pip==8.1.1
+angr>=8.19.7.25

--- a/tests/sources/fuzz_examples/hang-test/main.c
+++ b/tests/sources/fuzz_examples/hang-test/main.c
@@ -5,8 +5,29 @@
 #define REPS 100
 #define SLEEP_TIME 1000
 
+// for both direct and indirect recursion in callgraph
+
+int recursive_fun(int);
+
+int foo(){
+	recursive_fun(1);
+}
+
+int recursive_fun(int value){
+	if (value == 3){
+		foo();
+	}
+	else if (value == 2)
+		recursive_fun(1);
+	else
+		return 0;
+}
+
+
 int main(int argc, char ** argv){
 	FILE * fp = fopen(argv[1],"r");
+	fclose(fp);
+	fp = fopen(argv[1],"r");
 	int num;
 	fscanf(fp,"%d ",&num);
 	if( num != 5 ){
@@ -15,5 +36,8 @@ int main(int argc, char ** argv){
 			usleep(SLEEP_TIME);
 	}
 	fclose(fp);
+	recursive_fun(argc);
+	foo();
+	// foo();
 	return 0;
 }


### PR DESCRIPTION
This pull request adds a new approach to the existing solution of coverage analysis within performance fuzzing: static call graph analysis. Using new `gcov` JSON output format we can associate the coverage data with the call graph nodes easily and effectively and therefore we obtain more sophisticated coverage-performance indicator. This approach should improve the ability of recognition and finding new workloads which badly affect the SUT.