### PR TITLE
profile/factory: Import MutableMapping base class from collections.abc

### DIFF
--- a/perun/profile/factory.py
+++ b/perun/profile/factory.py
@@ -22,7 +22,7 @@ from perun.postprocess.regressogram.methods import get_supported_nparam_methods
 __author__ = 'Tomas Fiedor'
 
 
-class Profile(collections.MutableMapping):
+class Profile(collections.abc.MutableMapping):
     """
     :ivar dict _storage: internal storage of the profile
     :ivar dict _tuple_to_resource_type_map: map of tuple of persistent records of resources to


### PR DESCRIPTION
Importing abstract base classes from collections has been marked as
deprecated in Python 3.3[0] in favor of importing from collections.abc.
The deprecation has been finished in Python 3.9[1]

[0] https://github.com/python/cpython/issues/55294 [1] https://github.com/python/cpython/issues/70176