### PR TITLE
Enhancement of reports - top traces popup

### DIFF
--- a/perun/templates/diff_components/trace_details_modal.html.jinja2
+++ b/perun/templates/diff_components/trace_details_modal.html.jinja2
@@ -49,7 +49,19 @@
         document.getElementById('trace-popup-container').style.display = 'flex';
 
         // Populate Header
-        document.getElementById('trace-popup-title').innerHTML = `Unit: ${rowData.uid} <span style="font-weight: bold; color: ${getColorForFreshness(rowData.fresh)}">(${rowData.fresh})</span>`;
+        const popupTitle = document.getElementById('trace-popup-title');
+        popupTitle.innerHTML = '';
+
+        const titleText = document.createElement('span');
+        titleText.className = 'trace-popup-title-text';
+        titleText.innerHTML = `Unit: ${rowData.uid} <span style="font-weight: bold; color: ${getColorForFreshness(rowData.fresh)}">(${rowData.fresh})</span>`;
+        popupTitle.appendChild(titleText);
+
+        if (rowData.uid) {
+            const copyTitleBtn = createCopyButton(rowData.uid, 'trace-popup-title-copy-btn');
+            copyTitleBtn.title = 'Copy function name';
+            popupTitle.appendChild(copyTitleBtn);
+        }
         document.getElementById('trace-info-text').innerHTML = `
             <div class="trace-header-stats">
                 <div class="stat-item stat-item-aligned-end">
@@ -203,38 +215,8 @@
                 funcName.textContent = name;
                 frame.appendChild(funcName);
 
-                // Copy button — fades in on hover, out on leave
-                const COPY_SVG = '<svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="9" y="9" width="13" height="13" rx="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg>';
-                const CHECK_SVG = '<svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"/></svg>';
-
-                const copyBtn = document.createElement('button');
-                copyBtn.className = 'callstack-copy-btn';
+                const copyBtn = createCopyButton(name, 'callstack-copy-btn');
                 copyBtn.title = 'Copy function name';
-                copyBtn.innerHTML = COPY_SVG;
-
-                // Per-frame hover state tracked via closure
-                let frameHovered = false;
-                const setIconVisible = (visible) => {
-                    const svg = copyBtn.querySelector('svg');
-                    if (svg) svg.style.opacity = visible ? '1' : '0';
-                };
-
-                frame.addEventListener('mouseenter', () => { frameHovered = true;  setIconVisible(true);  });
-                frame.addEventListener('mouseleave', () => { frameHovered = false; setIconVisible(false); });
-
-                copyBtn.addEventListener('click', (e) => {
-                    e.stopPropagation();
-                    navigator.clipboard.writeText(name).then(() => {
-                        copyBtn.classList.add('callstack-copy-btn--copied');
-                        copyBtn.innerHTML = CHECK_SVG;
-                        setIconVisible(frameHovered); // new SVG — re-apply current hover state
-                        setTimeout(() => {
-                            copyBtn.classList.remove('callstack-copy-btn--copied');
-                            copyBtn.innerHTML = COPY_SVG;
-                            setIconVisible(frameHovered); // new SVG again — re-apply
-                        }, 1500);
-                    });
-                });
                 frame.appendChild(copyBtn);
 
                 panel.appendChild(frame);

--- a/perun/templates/diff_components/trace_details_modal.html.jinja2
+++ b/perun/templates/diff_components/trace_details_modal.html.jinja2
@@ -271,7 +271,7 @@
                     render: (data) => {
                         return `<div class="trace-cell-compact trace-cell-clickable" title="Click to view call chain">${data}</div>`;
                     },
-                    width: '90px',
+                    width: '60px',
                     tooltip: TRACES_TOOLTIPS.index
                 },
                 {
@@ -280,7 +280,7 @@
                     type: 'number',
                     filterable: false,
                     render: (data) => `<div class="trace-cell-compact">${data}</div>`,
-                    width: '90px',
+                    width: '65px',
                     tooltip: TRACES_TOOLTIPS.depth
                 },
                 {

--- a/perun/templates/diff_components/trace_details_modal.html.jinja2
+++ b/perun/templates/diff_components/trace_details_modal.html.jinja2
@@ -243,7 +243,7 @@
                 if (i < totalDepth - 1) {
                     const connector = document.createElement('div');
                     connector.className = 'callstack-connector';
-                    connector.innerHTML = '<span class="callstack-arrow">&#8595;</span>';
+                    connector.innerHTML = '<span class="callstack-arrow">&#8593;</span>';
                     panel.appendChild(connector);
                 }
             });
@@ -280,7 +280,7 @@
                     type: 'number',
                     filterable: false,
                     render: (data) => `<div class="trace-cell-compact">${data}</div>`,
-                    width: '65px',
+                    width: '85px',
                     tooltip: TRACES_TOOLTIPS.depth
                 },
                 {

--- a/perun/templates/diff_components/trace_details_modal.html.jinja2
+++ b/perun/templates/diff_components/trace_details_modal.html.jinja2
@@ -1,13 +1,26 @@
 <div id="trace-popup-container" style="display: none">
     <div class="note-overlay" onclick="closeTracePopup()"></div>
 
+    <button id="trace-popup-prev" class="trace-popup-nav-btn trace-popup-nav-btn--prev" onclick="navigatePopup(-1)" title="Previous function (Left Arrow)">
+        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="15 18 9 12 15 6"/></svg>
+    </button>
+
+    <button id="trace-popup-next" class="trace-popup-nav-btn trace-popup-nav-btn--next" onclick="navigatePopup(1)" title="Next function (Right Arrow)">
+        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="9 18 15 12 9 6"/></svg>
+    </button>
+
     <div class="note-popup" id="trace-popup">
 
         <span id="trace-popup-close" onclick="closeTracePopup()">
             {% include 'assets/close.svg' %}
         </span>
 
-        <h2 id="trace-popup-title">Trace Details</h2>
+        <div id="trace-popup-title-bar">
+            <h2 id="trace-popup-title">Trace Details</h2>
+            <div id="trace-popup-nav-badge" class="trace-popup-nav-badge" style="display: none;">
+                <span id="trace-popup-nav-counter">1 / 20</span>
+            </div>
+        </div>
 
         <div id="trace-popup-content-wrapper">
             <div id="trace-popup-header">
@@ -35,18 +48,87 @@
 </div>
 
 <script>
+    let currentPopupNavContext = null;
+
     function closeTracePopup() {
         document.getElementById('trace-popup-container').style.display = 'none';
+        currentPopupNavContext = null;
+    }
+
+    function getRowDataFromNavContextItem(item) {
+        if (!item) return null;
+        if (item.uid && item.index) {
+            return item;
+        }
+        if (Array.isArray(item) && window.tracesData) {
+            const nodeIdStr = item[0].toString();
+            return window.tracesData.find(r => r.index === nodeIdStr) || null;
+        }
+        return null;
+    }
+
+    function navigatePopup(direction) {
+        if (!currentPopupNavContext || !currentPopupNavContext.items) return;
+
+        const newIndex = currentPopupNavContext.currentIndex + direction;
+        if (newIndex < 0 || newIndex >= currentPopupNavContext.items.length) return;
+
+        const item = currentPopupNavContext.items[newIndex];
+        const rowData = getRowDataFromNavContextItem(item);
+        if (rowData) {
+            openTracePopup(rowData, currentPopupNavContext.isExclusive, {
+                ...currentPopupNavContext,
+                currentIndex: newIndex
+            });
+        }
     }
 
     document.addEventListener('keydown', (event) => {
-        if (event.key === 'Escape') {
-            closeTracePopup();
+        const container = document.getElementById('trace-popup-container');
+        if (container && container.style.display !== 'none') {
+            if (event.key === 'Escape') {
+                closeTracePopup();
+            } else if (event.key === 'ArrowLeft') {
+                event.preventDefault();
+                navigatePopup(-1);
+            } else if (event.key === 'ArrowRight') {
+                event.preventDefault();
+                navigatePopup(1);
+            }
         }
     });
 
-    function openTracePopup(rowData, isExclusive) {
+    function openTracePopup(rowData, isExclusive, navContext) {
         document.getElementById('trace-popup-container').style.display = 'flex';
+
+        currentPopupNavContext = navContext || null;
+
+        const prevBtn = document.getElementById('trace-popup-prev');
+        const nextBtn = document.getElementById('trace-popup-next');
+        const navBadge = document.getElementById('trace-popup-nav-badge');
+        const counterSpan = document.getElementById('trace-popup-nav-counter');
+
+        if (currentPopupNavContext && currentPopupNavContext.items && currentPopupNavContext.items.length > 1) {
+            const total = currentPopupNavContext.items.length;
+            const curIdx = currentPopupNavContext.currentIndex;
+
+            if (prevBtn) {
+                prevBtn.style.display = 'flex';
+                prevBtn.disabled = curIdx <= 0;
+            }
+            if (nextBtn) {
+                nextBtn.style.display = 'flex';
+                nextBtn.disabled = curIdx >= total - 1;
+            }
+            if (navBadge) {
+                navBadge.style.display = 'inline-flex';
+                if (counterSpan) counterSpan.textContent = `${curIdx + 1} / ${total}`;
+            }
+        } else {
+            if (prevBtn) prevBtn.style.display = 'none';
+            if (nextBtn) nextBtn.style.display = 'none';
+            if (navBadge) navBadge.style.display = 'none';
+        }
 
         // Populate Header
         const popupTitle = document.getElementById('trace-popup-title');

--- a/perun/templates/diff_components/traces_table.html.jinja2
+++ b/perun/templates/diff_components/traces_table.html.jinja2
@@ -162,9 +162,16 @@
             itemsPerPage: 10,
             initialSortColumn: 'prop_rel_delta_incl',
             initialSortDirection: 'desc',
-            onRowClick: (row) => {
+            onRowClick: (row, tr, tableInstance) => {
                 if (window.openTracePopup) {
-                    window.openTracePopup(row, false);
+                    const items = (tableInstance && tableInstance.processedData) ? tableInstance.processedData : rawData;
+                    const index = items.findIndex(r => r.index === row.index || r.uid === row.uid);
+                    const navContext = {
+                        items: items,
+                        currentIndex: index !== -1 ? index : 0,
+                        isExclusive: false
+                    };
+                    window.openTracePopup(row, false, navContext);
                 }
             }
         });
@@ -176,9 +183,16 @@
             itemsPerPage: 10,
             initialSortColumn: 'prop_rel_delta_excl',
             initialSortDirection: 'desc',
-            onRowClick: (row) => {
+            onRowClick: (row, tr, tableInstance) => {
                 if (window.openTracePopup) {
-                    window.openTracePopup(row, true);
+                    const items = (tableInstance && tableInstance.processedData) ? tableInstance.processedData : rawData;
+                    const index = items.findIndex(r => r.index === row.index || r.uid === row.uid);
+                    const navContext = {
+                        items: items,
+                        currentIndex: index !== -1 ? index : 0,
+                        isExclusive: true
+                    };
+                    window.openTracePopup(row, true, navContext);
                 }
             }
         });

--- a/perun/templates/diff_sections/section_overview.html.jinja2
+++ b/perun/templates/diff_sections/section_overview.html.jinja2
@@ -4,6 +4,7 @@
 {% import 'macros/rating_slider.html.jinja2' as summary_tools %}
 {% import 'macros/traces_selection.html.jinja2' as traces_selection %}
 {% import 'macros/section_title.html.jinja2' as m_title %}
+{% import 'macros/pin.html.jinja2' as m_pin %}
 
 {% set STATS_NOTE_TITLE = "overview" %}
 
@@ -93,7 +94,19 @@
     </div>
 #}
 
-    {{ m_title.display_subtitle("Top Functions", "top-functions") }}
+    <div class="section_header top-funcs-header">
+        <span class="top-funcs-title">Top Functions</span>
+        <div class="incl-excl-toggle-wrapper" title="Switch between inclusive (cumulative) and exclusive (self-only) samples">
+            <span class="incl-excl-label" id="incl-excl-label-left">Inclusive</span>
+            <label class="ios-toggle">
+                <input type="checkbox" id="top-funcs-incl-excl-toggle" onchange="onInclExclToggle()">
+                <span class="ios-toggle-track">
+                    <span class="ios-toggle-thumb"></span>
+                </span>
+            </label>
+            <span class="incl-excl-label" id="incl-excl-label-right">Exclusive</span>
+        </div>
+    </div>
     <div class="comparison_container">
         {{ traces_selection.empty_table('Baseline-Only', 'top-funcs-baseline') }}
         {{ traces_selection.empty_table_switchable('Common', 'top-funcs-common') }}
@@ -194,7 +207,7 @@
             const value = row[1];
             const percentage = value.toFixed(2);
             const sign = value > 0 ? '+' : '';
-            const colorClass = value >= 0 ? 'diff-plus' : 'diff-minus';
+            const colorClass = value >= 0 ? 'diff-minus' : 'diff-plus';
             
             valDiv.innerHTML = `<span class="${colorClass}" style="margin-left: 8px; font-weight: bold;">${sign}${percentage}%</span>`;
 
@@ -205,49 +218,58 @@
     }
 
 
-    function updateTables() {
-        /*
-        // Traces - Currently commented out, update logic to new toggle if re-enabled
-        renderTable('top-traces-baseline', topTraceDiffs[0][0]);
-        renderTable('top-traces-target', topTraceDiffs[0][1]);
-        
-        const tracesToggle = document.getElementById('top-traces-common-sort-toggle');
-        if (tracesToggle) {
-            const isDescending = tracesToggle.getAttribute('data-sort') === 'desc';
-            const tracesCommonData = isDescending ? topTraceDiffs[0][2] : topTraceDiffs[0][3];
-            renderTable('top-traces-common', tracesCommonData);
-        }
-        */
+    function getInclExclIndex() {
+        const toggle = document.getElementById('top-funcs-incl-excl-toggle');
+        return toggle && toggle.checked ? 1 : 0;
+    }
 
-        // Functions
-        renderTable('top-funcs-baseline', topFunctionDiffs[0][0]);
-        renderTable('top-funcs-target', topFunctionDiffs[0][1]);
-        
+    function updateTables() {
+        const idx = getInclExclIndex();
+
+        renderTable('top-funcs-baseline', topFunctionDiffs[idx][0]);
+        renderTable('top-funcs-target', topFunctionDiffs[idx][1]);
+
         const funcsToggle = document.getElementById('top-funcs-common-sort-toggle');
         if (funcsToggle) {
             const isDescending = funcsToggle.getAttribute('data-sort') === 'desc';
-            const funcsCommonData = isDescending ? topFunctionDiffs[0][2] : topFunctionDiffs[0][3];
+            const funcsCommonData = isDescending ? topFunctionDiffs[idx][2] : topFunctionDiffs[idx][3];
             renderTable('top-funcs-common', funcsCommonData);
         }
+    }
+
+    function onInclExclToggle() {
+        const isExcl = document.getElementById('top-funcs-incl-excl-toggle').checked;
+        const leftLabel = document.getElementById('incl-excl-label-left');
+        const rightLabel = document.getElementById('incl-excl-label-right');
+        if (leftLabel)  leftLabel.classList.toggle('incl-excl-label--active', !isExcl);
+        if (rightLabel) rightLabel.classList.toggle('incl-excl-label--active', isExcl);
+        updateTables();
     }
 
     function toggleTable(id) {
         const toggle = document.getElementById(id + '-sort-toggle');
         if (!toggle) return;
-        
+
         const currentSort = toggle.getAttribute('data-sort');
         const newSort = currentSort === 'desc' ? 'asc' : 'desc';
-        
+
         toggle.setAttribute('data-sort', newSort);
         document.getElementById(id + '-sort-label').textContent = newSort === 'desc' ? 'Descending' : 'Ascending';
         document.getElementById(id + '-sort-arrow').textContent = newSort === 'desc' ? '▼' : '▲';
-        
+
         updateTables();
     }
 
     // Execute immediately after DOM is loaded or script runs
-    document.addEventListener("DOMContentLoaded", updateTables);
+    document.addEventListener("DOMContentLoaded", () => {
+        updateTables();
+        // Set initial active state on Incl. label
+        const leftLabel = document.getElementById('incl-excl-label-left');
+        if (leftLabel) leftLabel.classList.add('incl-excl-label--active');
+    });
     if (document.readyState === "complete" || document.readyState === "interactive") {
         updateTables();
+        const leftLabel = document.getElementById('incl-excl-label-left');
+        if (leftLabel) leftLabel.classList.add('incl-excl-label--active');
     }
 </script>

--- a/perun/templates/diff_sections/section_overview.html.jinja2
+++ b/perun/templates/diff_sections/section_overview.html.jinja2
@@ -187,21 +187,13 @@
                 if (window.tracesData) {
                     const rowData = window.tracesData.find(r => r.index === row[0].toString());
                     if (rowData && window.openTracePopup) {
-                        window.openTracePopup(rowData);
-
-                        if (window.tracesTable) {
-                            const indexInProcessed = window.tracesTable.processedData.findIndex(r => r.index === rowData.index);
-                            if (indexInProcessed !== -1) {
-                                const page = Math.floor(indexInProcessed / window.tracesTable.itemsPerPage) + 1;
-                                window.tracesTable.changePage(page);
-                                window.tracesTable.render();
-                            }
-                        }
-
-                        const tracesSection = document.getElementById('traces');
-                        if (tracesSection) {
-                            tracesSection.scrollIntoView({ behavior: 'smooth' });
-                        }
+                        const isExcl = getInclExclIndex() === 1;
+                        const navContext = {
+                            items: dataArray,
+                            currentIndex: index,
+                            isExclusive: isExcl
+                        };
+                        window.openTracePopup(rowData, isExcl, navContext);
                     }
                 }
             };

--- a/perun/templates/diff_sections/section_overview.html.jinja2
+++ b/perun/templates/diff_sections/section_overview.html.jinja2
@@ -96,15 +96,13 @@
 
     <div class="section_header top-funcs-header">
         <span class="top-funcs-title">Top Functions</span>
-        <div class="incl-excl-toggle-wrapper" title="Switch between inclusive (cumulative) and exclusive (self-only) samples">
-            <span class="incl-excl-label" id="incl-excl-label-left">Inclusive</span>
-            <label class="ios-toggle">
-                <input type="checkbox" id="top-funcs-incl-excl-toggle" onchange="onInclExclToggle()">
-                <span class="ios-toggle-track">
-                    <span class="ios-toggle-thumb"></span>
-                </span>
+        <div class="segmented-toggle" title="Switch between inclusive (cumulative) and exclusive (self-only) samples">
+            <input type="checkbox" id="top-funcs-incl-excl-toggle" onchange="onInclExclToggle()">
+            <label for="top-funcs-incl-excl-toggle" class="segmented-toggle-label">
+                <span class="segmented-slider"></span>
+                <span class="segmented-option seg-incl">Inclusive</span>
+                <span class="segmented-option seg-excl">Exclusive</span>
             </label>
-            <span class="incl-excl-label" id="incl-excl-label-right">Exclusive</span>
         </div>
     </div>
     <div class="comparison_container">
@@ -248,11 +246,6 @@
     }
 
     function onInclExclToggle() {
-        const isExcl = document.getElementById('top-funcs-incl-excl-toggle').checked;
-        const leftLabel = document.getElementById('incl-excl-label-left');
-        const rightLabel = document.getElementById('incl-excl-label-right');
-        if (leftLabel)  leftLabel.classList.toggle('incl-excl-label--active', !isExcl);
-        if (rightLabel) rightLabel.classList.toggle('incl-excl-label--active', isExcl);
         updateTables();
     }
 
@@ -273,13 +266,8 @@
     // Execute immediately after DOM is loaded or script runs
     document.addEventListener("DOMContentLoaded", () => {
         updateTables();
-        // Set initial active state on Incl. label
-        const leftLabel = document.getElementById('incl-excl-label-left');
-        if (leftLabel) leftLabel.classList.add('incl-excl-label--active');
     });
     if (document.readyState === "complete" || document.readyState === "interactive") {
         updateTables();
-        const leftLabel = document.getElementById('incl-excl-label-left');
-        if (leftLabel) leftLabel.classList.add('incl-excl-label--active');
     }
 </script>

--- a/perun/templates/diff_sections/section_overview.html.jinja2
+++ b/perun/templates/diff_sections/section_overview.html.jinja2
@@ -169,10 +169,17 @@
             container.innerHTML = '<div style="font-style: italic; color: #888; padding: 10px;">No data</div>';
             return;
         }
-        dataArray.forEach(row => {
+        dataArray.forEach((row, index) => {
             const rowDiv = document.createElement('div');
             rowDiv.className = 'data-row';
-            
+
+            const keyWrapper = document.createElement('div');
+            keyWrapper.className = 'data-key-wrapper';
+
+            const idxSpan = document.createElement('span');
+            idxSpan.className = 'data-idx';
+            idxSpan.textContent = `${index + 1}.`;
+
             const keyDiv = document.createElement('div');
             keyDiv.className = 'data-key';
             const functionName = nodes[row[0]] || row[0];
@@ -201,6 +208,9 @@
                 }
             };
 
+            keyWrapper.appendChild(idxSpan);
+            keyWrapper.appendChild(keyDiv);
+
             const valDiv = document.createElement('div');
             valDiv.className = 'data-value';
             
@@ -211,7 +221,7 @@
             
             valDiv.innerHTML = `<span class="${colorClass}" style="margin-left: 8px; font-weight: bold;">${sign}${percentage}%</span>`;
 
-            rowDiv.appendChild(keyDiv);
+            rowDiv.appendChild(keyWrapper);
             rowDiv.appendChild(valDiv);
             container.appendChild(rowDiv);
         });

--- a/perun/templates/scripts/traces_table.js
+++ b/perun/templates/scripts/traces_table.js
@@ -1,5 +1,5 @@
 /* global formatNumber */
-/* exported TRACES_TOOLTIPS, TracesTable */
+/* exported TRACES_TOOLTIPS, TracesTable, createCopyButton */
 
 const TRACES_TOOLTIPS = {
     index: 'The trace index.',
@@ -10,6 +10,31 @@ const TRACES_TOOLTIPS = {
     rel_delta: 'The difference of Target - Baseline resource consumption in relative terms. For example, if the baseline and target consumed 2M and 1M CPU cycles in total, respectively, and a function \'foo\' consumed 100K and 80K cycles in baseline, resp. target, the relative difference is -20%.',
     depth: 'Number of frames in the call stack for this trace.'
 };
+
+const COPY_SVG = '<svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="9" y="9" width="13" height="13" rx="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg>';
+const CHECK_SVG = '<svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"/></svg>';
+
+function createCopyButton(textToCopy, extraClass = '') {
+    const copyBtn = document.createElement('button');
+    copyBtn.className = 'copy-btn' + (extraClass ? ' ' + extraClass : '');
+    copyBtn.title = 'Copy to clipboard';
+    copyBtn.innerHTML = COPY_SVG;
+
+    copyBtn.addEventListener('click', (e) => {
+        e.stopPropagation();
+        if (!textToCopy) return;
+        navigator.clipboard.writeText(textToCopy).then(() => {
+            copyBtn.classList.add('copy-btn--copied', 'copied');
+            copyBtn.innerHTML = CHECK_SVG;
+            setTimeout(() => {
+                copyBtn.classList.remove('copy-btn--copied', 'copied');
+                copyBtn.innerHTML = COPY_SVG;
+            }, 1500);
+        });
+    });
+
+    return copyBtn;
+}
 
 class TracesTable {
     constructor(containerId, options = {}) {
@@ -350,7 +375,21 @@ class TracesTable {
                         content = formatNumber(content);
                     }
                     if (col.data === 'uid') {
-                        td.innerHTML = `<span class="trace-uid" style="display: block; width: 100%; height: 100%;" title="Click to view more details about the trace">${content !== undefined ? content : ''}</span>`;
+                        const wrapper = document.createElement('div');
+                        wrapper.className = 'trace-uid-wrapper';
+
+                        const span = document.createElement('span');
+                        span.className = 'trace-uid';
+                        span.title = 'Click to view more details about the trace';
+                        span.textContent = content !== undefined ? content : '';
+                        wrapper.appendChild(span);
+
+                        if (content) {
+                            const copyBtn = createCopyButton(content, 'trace-uid-copy-btn');
+                            copyBtn.title = 'Copy function name';
+                            wrapper.appendChild(copyBtn);
+                        }
+                        td.appendChild(wrapper);
                     } else {
                         td.innerText = content !== undefined ? content : '';
                     }

--- a/perun/templates/scripts/traces_table.js
+++ b/perun/templates/scripts/traces_table.js
@@ -23,14 +23,20 @@ function createCopyButton(textToCopy, extraClass = '') {
     copyBtn.addEventListener('click', (e) => {
         e.stopPropagation();
         if (!textToCopy) return;
-        navigator.clipboard.writeText(textToCopy).then(() => {
+        const markCopied = () => {
             copyBtn.classList.add('copy-btn--copied', 'copied');
             copyBtn.innerHTML = CHECK_SVG;
             setTimeout(() => {
                 copyBtn.classList.remove('copy-btn--copied', 'copied');
                 copyBtn.innerHTML = COPY_SVG;
             }, 1500);
-        });
+        };
+
+        if (navigator.clipboard && navigator.clipboard.writeText) {
+            navigator.clipboard.writeText(textToCopy).then(markCopied).catch(err => {
+                console.error('Failed to copy text: ', err);
+            });
+        }
     });
 
     return copyBtn;

--- a/perun/templates/scripts/traces_table.js
+++ b/perun/templates/scripts/traces_table.js
@@ -411,7 +411,7 @@ class TracesTable {
             if (this.onRowClick) {
                 tr.style.cursor = 'pointer';
                 tr.addEventListener('click', () => {
-                    this.onRowClick(row, tr);
+                    this.onRowClick(row, tr, this);
                 });
             }
 

--- a/perun/templates/style/colors_setup.css
+++ b/perun/templates/style/colors_setup.css
@@ -81,6 +81,7 @@ body.dark-theme {
     --color-primary: rgba(255 255 255);
     --color-primary-transparent: rgba(255 255 255 / 30%);
     --color-primary-hover: rgba(234 234 234);
+    --color-bs-secondary: rgba(160 174 192);
 
     --color-secondary: rgba(51 51 51);
     --color-secondary-hover: rgba(41 41 41);

--- a/perun/templates/style/layout.css
+++ b/perun/templates/style/layout.css
@@ -76,12 +76,13 @@
     padding: 10px 20px;
     font-size: 0.9em;
     border-bottom: 1px solid var(--color-white-tinted);
+    overflow: hidden;
 }
 
 .data-key-wrapper {
     display: flex;
     align-items: center;
-    min-width: 0;
+    min-width: 120px;
     flex: 1;
     overflow: hidden;
 }
@@ -117,9 +118,12 @@
 
 .data-value {
     text-align: right;
-    overflow: auto;
+    word-break: break-all;
+    overflow-wrap: break-word;
     color: var(--color-primary-text);
-    flex-shrink: 0;
+    flex-shrink: 1;
+    min-width: 0;
+    max-width: 70%;
 }
 
 .sort-toggle {

--- a/perun/templates/style/layout.css
+++ b/perun/templates/style/layout.css
@@ -78,6 +78,26 @@
     border-bottom: 1px solid var(--color-white-tinted);
 }
 
+.data-key-wrapper {
+    display: flex;
+    align-items: center;
+    min-width: 0;
+    flex: 1;
+    overflow: hidden;
+}
+
+.data-idx {
+    font-weight: bold;
+    font-size: 0.85em;
+    color: var(--color-primary-text);
+    opacity: 0.7;
+    min-width: 22px;
+    text-align: right;
+    margin-right: 8px;
+    flex-shrink: 0;
+    user-select: none;
+}
+
 .data-key,
 .data-value {
     margin: 0 10px;
@@ -90,12 +110,16 @@
     text-align: left;
     margin-right: 10px;
     cursor: pointer;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
 }
 
 .data-value {
     text-align: right;
     overflow: auto;
     color: var(--color-primary-text);
+    flex-shrink: 0;
 }
 
 .sort-toggle {

--- a/perun/templates/style/overview.css
+++ b/perun/templates/style/overview.css
@@ -222,7 +222,7 @@ body.mono-theme .top-traces-column:hover {
     }
 }
 
-/* ── Inclusive / Exclusive toggle ─────────────────────────────── */
+/* ── Segmented Inclusive / Exclusive Pill Toggle ─────────────────────────────── */
 
 .top-funcs-header {
     margin-top: 40px;
@@ -235,33 +235,14 @@ body.mono-theme .top-traces-column:hover {
     white-space: nowrap;
 }
 
-.incl-excl-toggle-wrapper {
+.segmented-toggle {
     display: inline-flex;
-    align-items: center;
-    gap: 6px;
-    padding: 4px 10px;
-    border-radius: 999px;
-    background: var(--color-primary-transparent);
+    position: relative;
     user-select: none;
     flex-shrink: 0;
 }
 
-.incl-excl-label {
-    font-size: 0.78rem;
-    font-weight: 600;
-    color: var(--color-primary-text);
-    transition: color 0.2s, opacity 0.2s;
-    opacity: 0.9;
-    letter-spacing: 0.03em;
-}
-
-.incl-excl-label--active {
-    color: var(--color-primary);
-    opacity: 1;
-}
-
-/* The hidden native checkbox */
-.ios-toggle input[type="checkbox"] {
+.segmented-toggle input[type="checkbox"] {
     position: absolute;
     width: 0;
     height: 0;
@@ -269,52 +250,72 @@ body.mono-theme .top-traces-column:hover {
     pointer-events: none;
 }
 
-.ios-toggle {
-    position: relative;
+.segmented-toggle-label {
     display: inline-flex;
     align-items: center;
-    cursor: pointer;
-}
-
-.ios-toggle-track {
-    display: flex;
-    align-items: center;
-    width: 40px;
-    height: 22px;
-    border-radius: 999px;
-    background: var(--color-light-gray, #d1d5db);
-    transition: all 0.25s ease;
     position: relative;
-    padding: 2px;
-    box-sizing: border-box;
+    background-color: var(--color-primary-transparent);
+    border-radius: 999px;
+    padding: 3px;
+    cursor: pointer;
+    overflow: hidden;
+    transition: all 0.25s ease;
 }
 
-.ios-toggle-thumb {
-    width: 18px;
-    height: 18px;
-    border-radius: 50%;
-    background: #fff;
-    box-shadow: 0 1px 4px rgba(0, 0, 0, 0.3);
-    transition: transform 0.25s cubic-bezier(0.4, 0, 0.2, 1), background 0.25s;
-    flex-shrink: 0;
+.segmented-slider {
+    position: absolute;
+    top: 3px;
+    bottom: 3px;
+    left: 3px;
+    width: calc(50% - 3px);
+    background-color: var(--color-target);
+    border-radius: 999px;
+    transition: transform 0.25s cubic-bezier(0.4, 0, 0.2, 1);
+    box-shadow: 0 2px 5px rgba(0, 0, 0, 0.2);
+    z-index: 1;
 }
 
-.ios-toggle input:checked+.ios-toggle-track {
-    background: var(--color-primary);
+.segmented-toggle input:checked + .segmented-toggle-label .segmented-slider {
+    transform: translateX(100%);
 }
 
-.ios-toggle input:checked+.ios-toggle-track .ios-toggle-thumb {
-    transform: translateX(18px);
+.segmented-option {
+    position: relative;
+    z-index: 2;
+    padding: 5px 14px;
+    font-size: 0.85rem;
+    font-weight: bold;
+    color: var(--color-primary-text);
+    transition: color 0.25s ease;
+    text-align: center;
+    white-space: nowrap;
+    width: 90px;
 }
 
-body.dark-theme .incl-excl-toggle-wrapper {
-    background: rgba(255, 255, 255, 0.07);
+.segmented-option.seg-incl {
+    color: var(--color-white-not-changing);
 }
 
-body.mono-theme .incl-excl-toggle-wrapper {
-    background: var(--color-bg-btn-tinted);
+.segmented-option.seg-excl {
+    color: var(--color-primary-text);
 }
 
-body.mono-theme .ios-toggle input:checked+.ios-toggle-track {
-    background: var(--color-primary);
+.segmented-toggle input:checked + .segmented-toggle-label .segmented-option.seg-incl {
+    color: var(--color-primary-text);
+}
+
+.segmented-toggle input:checked + .segmented-toggle-label .segmented-option.seg-excl {
+    color: var(--color-white-not-changing);
+}
+
+body.dark-theme .segmented-toggle-label {
+    background-color: rgba(255, 255, 255, 0.08);
+}
+
+body.mono-theme .segmented-toggle-label {
+    background-color: var(--color-bg-btn-tinted);
+}
+
+body.mono-theme .segmented-slider {
+    background-color: var(--color-primary);
 }

--- a/perun/templates/style/overview.css
+++ b/perun/templates/style/overview.css
@@ -221,3 +221,100 @@ body.mono-theme .top-traces-column:hover {
         font-size: 1rem;
     }
 }
+
+/* ── Inclusive / Exclusive toggle ─────────────────────────────── */
+
+.top-funcs-header {
+    margin-top: 40px;
+}
+
+.top-funcs-title {
+    font-size: 1.5em;
+    font-weight: bold;
+    color: var(--color-primary);
+    white-space: nowrap;
+}
+
+.incl-excl-toggle-wrapper {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    padding: 4px 10px;
+    border-radius: 999px;
+    background: var(--color-primary-transparent);
+    user-select: none;
+    flex-shrink: 0;
+}
+
+.incl-excl-label {
+    font-size: 0.78rem;
+    font-weight: 600;
+    color: var(--color-primary-text);
+    transition: color 0.2s, opacity 0.2s;
+    opacity: 0.9;
+    letter-spacing: 0.03em;
+}
+
+.incl-excl-label--active {
+    color: var(--color-primary);
+    opacity: 1;
+}
+
+/* The hidden native checkbox */
+.ios-toggle input[type="checkbox"] {
+    position: absolute;
+    width: 0;
+    height: 0;
+    opacity: 0;
+    pointer-events: none;
+}
+
+.ios-toggle {
+    position: relative;
+    display: inline-flex;
+    align-items: center;
+    cursor: pointer;
+}
+
+.ios-toggle-track {
+    display: flex;
+    align-items: center;
+    width: 40px;
+    height: 22px;
+    border-radius: 999px;
+    background: var(--color-light-gray, #d1d5db);
+    transition: all 0.25s ease;
+    position: relative;
+    padding: 2px;
+    box-sizing: border-box;
+}
+
+.ios-toggle-thumb {
+    width: 18px;
+    height: 18px;
+    border-radius: 50%;
+    background: #fff;
+    box-shadow: 0 1px 4px rgba(0, 0, 0, 0.3);
+    transition: transform 0.25s cubic-bezier(0.4, 0, 0.2, 1), background 0.25s;
+    flex-shrink: 0;
+}
+
+.ios-toggle input:checked+.ios-toggle-track {
+    background: var(--color-primary);
+}
+
+.ios-toggle input:checked+.ios-toggle-track .ios-toggle-thumb {
+    transform: translateX(18px);
+}
+
+body.dark-theme .incl-excl-toggle-wrapper {
+    background: rgba(255, 255, 255, 0.07);
+}
+
+body.mono-theme .incl-excl-toggle-wrapper {
+    background: var(--color-bg-btn-tinted);
+}
+
+body.mono-theme .ios-toggle input:checked+.ios-toggle-track {
+    background: var(--color-primary);
+}

--- a/perun/templates/style/trace_details.css
+++ b/perun/templates/style/trace_details.css
@@ -29,13 +29,21 @@
   color: var(--color-primary-text);
 }
 
-#trace-popup-title {
-  margin: 0;
-  padding-bottom: 10px;
-  border-bottom: 2px solid var(--color-light-gray);
+#trace-popup-title-bar {
   display: flex;
   align-items: center;
   justify-content: space-between;
+  border-bottom: 2px solid var(--color-light-gray);
+  padding-bottom: 10px;
+  gap: 15px;
+}
+
+#trace-popup-title {
+  margin: 0;
+  border-bottom: none;
+  padding-bottom: 0;
+  display: flex;
+  align-items: center;
   gap: 12px;
   font-size: 1.5em;
   font-weight: bold;
@@ -43,6 +51,64 @@
 
 .trace-popup-title-text {
   font-size: 1em;
+}
+
+.trace-popup-nav-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 12px;
+  border-radius: 999px;
+  background-color: var(--color-target-transparent);
+  border: 1px solid var(--color-target);
+  font-size: 0.85em;
+  font-weight: bold;
+  color: var(--color-primary-text);
+  margin-right: 40px;
+}
+
+.trace-popup-nav-btn {
+  position: absolute;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  background-color: var(--color-secondary);
+  border: 2px solid var(--color-target);
+  color: var(--color-target);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  z-index: 9999;
+  transition: opacity 0.15s ease;
+}
+
+.trace-popup-nav-btn--prev {
+  left: calc(10vw - 64px);
+}
+
+.trace-popup-nav-btn--next {
+  right: calc(10vw - 64px);
+}
+
+.trace-popup-nav-btn:hover:not(:disabled) {
+  opacity: 0.75;
+}
+
+.trace-popup-nav-btn:disabled {
+  opacity: 0.2;
+  cursor: not-allowed;
+}
+
+@media (max-width: 1400px) {
+  .trace-popup-nav-btn--prev {
+    left: 15px;
+  }
+  .trace-popup-nav-btn--next {
+    right: 15px;
+  }
 }
 
 

--- a/perun/templates/style/trace_details.css
+++ b/perun/templates/style/trace_details.css
@@ -45,31 +45,6 @@
   font-size: 1em;
 }
 
-.trace-popup-title-copy-btn {
-  flex-shrink: 0;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  background: none;
-  border: 1px solid var(--color-light-gray);
-  border-radius: 4px;
-  padding: 4px 8px;
-  cursor: pointer;
-  color: var(--color-bs-secondary);
-  line-height: 1;
-  transition: all 0.15s ease;
-}
-
-.trace-popup-title-copy-btn:hover {
-  background-color: var(--color-secondary-hover);
-  border-color: var(--color-target);
-  color: var(--color-primary-text);
-}
-
-.trace-popup-title-copy-btn.copied {
-  color: var(--color-correct) !important;
-  border-color: var(--color-correct) !important;
-}
 
 #trace-popup-content-wrapper {
   display: flex;
@@ -234,41 +209,6 @@
   font-weight: bold;
 }
 
-.callstack-copy-btn {
-  flex-shrink: 0;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  transition: all 0.15s ease;
-  background: none;
-  border: 1px solid transparent;
-  border-radius: 4px;
-  padding: 3px 5px;
-  cursor: pointer;
-  color: var(--color-bs-secondary);
-  line-height: 1;
-}
-
-.callstack-copy-btn svg {
-  opacity: 0;
-  transition: opacity 0.15s ease;
-}
-
-.callstack-frame:hover .callstack-copy-btn svg {
-  opacity: 1;
-}
-
-
-.callstack-copy-btn:hover {
-  background-color: var(--color-secondary-hover);
-  border-color: var(--color-light-gray);
-  color: var(--color-primary-text);
-}
-
-.callstack-copy-btn--copied {
-  color: var(--color-correct) !important;
-  border-color: transparent !important;
-}
 
 .trace-cell-clickable {
   cursor: pointer;

--- a/perun/templates/style/trace_details.css
+++ b/perun/templates/style/trace_details.css
@@ -90,7 +90,7 @@
 }
 
 #trace-callstack-panel {
-  flex: 0 0 24%;
+  flex: 0 0 35%;
   min-width: 0;
   border: 2px solid var(--color-target);
   border-radius: 8px;

--- a/perun/templates/style/trace_details.css
+++ b/perun/templates/style/trace_details.css
@@ -33,6 +33,42 @@
   margin: 0;
   padding-bottom: 10px;
   border-bottom: 2px solid var(--color-light-gray);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  font-size: 1.5em;
+  font-weight: bold;
+}
+
+.trace-popup-title-text {
+  font-size: 1em;
+}
+
+.trace-popup-title-copy-btn {
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: none;
+  border: 1px solid var(--color-light-gray);
+  border-radius: 4px;
+  padding: 4px 8px;
+  cursor: pointer;
+  color: var(--color-bs-secondary);
+  line-height: 1;
+  transition: all 0.15s ease;
+}
+
+.trace-popup-title-copy-btn:hover {
+  background-color: var(--color-secondary-hover);
+  border-color: var(--color-target);
+  color: var(--color-primary-text);
+}
+
+.trace-popup-title-copy-btn.copied {
+  color: var(--color-correct) !important;
+  border-color: var(--color-correct) !important;
 }
 
 #trace-popup-content-wrapper {
@@ -203,7 +239,7 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  transition: color 0.15s ease, border-color 0.15s ease, background-color 0.15s ease;
+  transition: all 0.15s ease;
   background: none;
   border: 1px solid transparent;
   border-radius: 4px;
@@ -218,6 +254,10 @@
   transition: opacity 0.15s ease;
 }
 
+.callstack-frame:hover .callstack-copy-btn svg {
+  opacity: 1;
+}
+
 
 .callstack-copy-btn:hover {
   background-color: var(--color-secondary-hover);
@@ -226,7 +266,7 @@
 }
 
 .callstack-copy-btn--copied {
-  color: var(--color-success, #22c55e) !important;
+  color: var(--color-correct) !important;
   border-color: transparent !important;
 }
 

--- a/perun/templates/style/traces_table.css
+++ b/perun/templates/style/traces_table.css
@@ -330,3 +330,51 @@
     opacity: 1;
     pointer-events: auto;
 }
+
+.trace-uid-wrapper {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    width: 100%;
+    gap: 6px;
+}
+
+.trace-uid-wrapper .trace-uid {
+    flex: 1;
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.trace-uid-copy-btn {
+    flex-shrink: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: none;
+    border: 1px solid transparent;
+    border-radius: 4px;
+    padding: 3px 5px;
+    cursor: pointer;
+    color: var(--color-bs-secondary);
+    line-height: 1;
+    opacity: 0;
+    transition: all 0.15s ease;
+}
+
+.traces-table tbody tr:hover .trace-uid-copy-btn {
+    opacity: 1;
+}
+
+.trace-uid-copy-btn:hover {
+    background-color: var(--color-secondary-hover);
+    border-color: var(--color-light-gray);
+    color: var(--color-primary-text);
+}
+
+.trace-uid-copy-btn.copied {
+    color: var(--color-correct) !important;
+    border-color: transparent !important;
+    opacity: 1 !important;
+}

--- a/perun/templates/style/traces_table.css
+++ b/perun/templates/style/traces_table.css
@@ -24,7 +24,7 @@
 
 .traces-table th,
 .traces-table td {
-    padding: 12px 15px;
+    padding: 12px 10px;
     text-align: left;
     border-bottom: 1px solid var(--color-light-gray);
     white-space: nowrap;
@@ -48,7 +48,7 @@
 }
 
 .traces-table th.sortable {
-    padding-right: 30px;
+    padding-right: 20px;
 }
 
 .traces-table th.asc::after {
@@ -56,9 +56,10 @@
     font-size: 0.8em;
     color: var(--color-target);
     position: absolute;
-    right: 15px;
+    right: 3px;
     top: 50%;
     transform: translateY(-50%);
+    transition: opacity 0.2s;
 }
 
 .traces-table th.desc::after {
@@ -66,21 +67,29 @@
     font-size: 0.8em;
     color: var(--color-target);
     position: absolute;
-    right: 15px;
+    right: 3px;
     top: 50%;
     transform: translateY(-50%);
+    transition: opacity 0.2s;
+}
+
+.traces-table th.sortable:hover::after {
+    opacity: 0;
 }
 
 .header-info-icon {
+    position: absolute;
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    margin-left: 6px;
+    margin-left: 2px;
     opacity: 0;
     transition: opacity 0.2s;
-    width: 15px;
-    height: 15px;
-    vertical-align: middle;
+    width: 14px;
+    height: 14px;
+    top: 50%;
+    transform: translateY(-50%);
+    pointer-events: auto;
 }
 
 .traces-table th.sortable:hover .header-info-icon {

--- a/perun/templates/style/traces_table.css
+++ b/perun/templates/style/traces_table.css
@@ -347,9 +347,9 @@
     white-space: nowrap;
 }
 
-.trace-uid-copy-btn {
+.copy-btn {
     flex-shrink: 0;
-    display: flex;
+    display: inline-flex;
     align-items: center;
     justify-content: center;
     background: none;
@@ -363,17 +363,21 @@
     transition: all 0.15s ease;
 }
 
-.traces-table tbody tr:hover .trace-uid-copy-btn {
+.traces-table tbody tr:hover .copy-btn,
+.callstack-frame:hover .copy-btn,
+#trace-popup-title:hover .copy-btn,
+.copy-btn:hover {
     opacity: 1;
 }
 
-.trace-uid-copy-btn:hover {
+.copy-btn:hover {
     background-color: var(--color-secondary-hover);
     border-color: var(--color-light-gray);
     color: var(--color-primary-text);
 }
 
-.trace-uid-copy-btn.copied {
+.copy-btn.copied,
+.copy-btn.copy-btn--copied {
     color: var(--color-correct) !important;
     border-color: transparent !important;
     opacity: 1 !important;


### PR DESCRIPTION
This PR introduces new features for reports, particularly
- unify of copying of funcion names
- new inclusive/exclusive toggle in the summary tab
- numbering in the summary tab for top functions
- popups now have paging
  - from the top traces, they dont scroll down to the traces table, instead the viewport is positioned still on top and only popup is shows
  - new arrows on sides allow going through the list of the functions either by clicking the arrows or clicking arrows on keybord
  - this is also adjusted to browse through the regular traces table and also works with filtered array (e.g. based on some search query or sorting direction)
- unnecessary dots for narrower stacks were adjusted to not include `function_A...` when not needed
<img width="1470" height="772" alt="Screenshot 2026-08-18 at 10 22 01" src="https://github.com/user-attachments/assets/1477e4c0-b549-4ca9-b8c1-fc6f9e964584" />
<img width="1470" height="767" alt="Screenshot 2026-08-18 at 10 22 10" src="https://github.com/user-attachments/assets/32f40b52-9d99-4a55-90e8-684b69466c45" />