### PR TITLE
Add `--allow-unsafe-options` flag to vcs init

### DIFF
--- a/perun/cli.py
+++ b/perun/cli.py
@@ -275,6 +275,12 @@ def configure_local_perun(perun_path: str) -> None:
         " configurations."
     ),
 )
+@click.option(
+    "--allow-unsafe-options",
+    is_flag=True,
+    default=False,
+    help="Allow unsafe init options, e.g., ``--separate-git-dir``.",
+)
 def init(dst: str, configure: bool, config_template: str, **kwargs: Any) -> None:
     """Initializes performance versioning system at the destination path.
 

--- a/perun/logic/commands.py
+++ b/perun/logic/commands.py
@@ -206,22 +206,31 @@ def try_init():
             raise NotPerunRepositoryException(os.getcwd())
 
 
-def init(dst: str, configuration_template: str = "master", **kwargs: Any) -> None:
+def init(
+    dst: str,
+    configuration_template: str = "master",
+    allow_unsafe_options: bool = False,
+    **kwargs: Any,
+) -> None:
     """Initializes the performance and version control systems
 
     Inits the performance control system at a given directory. Optionally inits the
     wrapper of the Version Control System that is used as tracking point.
 
     :param dst: path where the pcs will be initialized
-    :param kwargs: keyword arguments of the initialization
     :param configuration_template: name of the template that will be used for initialization
         of local configuration
+    :param allow_unsafe_options: allow unsafe initialization options to be passed to GitPython
+    :param kwargs: keyword arguments of the initialization
     """
     perun_log.major_info("Initializing Perun")
     # First init the wrapping repository well
     vcs_type = kwargs["vcs_type"]
     vcs_path = kwargs.get("vcs_path", dst) or dst
     vcs_params = kwargs.get("vcs_params", {})
+    if vcs_params is None:
+        vcs_params = {}
+    vcs_params["allow_unsafe_options"] = allow_unsafe_options
 
     # Construct local config
     vcs_config = {"vcs": {"url": vcs_path, "type": vcs_type}}

--- a/perun/utils/log.py
+++ b/perun/utils/log.py
@@ -867,7 +867,7 @@ def progress(collection: Iterable[T], description: str = "") -> Iterable[T]:
     :param collection: any iterable
     :param description: tag on the left side of the output of the bar
     """
-    widgets = [
+    widgets: list[progressbar.widgets.WidgetBase | str] = [
         (description + ": ") if description else "",
         progressbar.Percentage(),
         " ",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1334,6 +1334,7 @@ def test_init_correct_with_params_and_flags():
             "--vcs-param",
             "separate-git-dir",
             "sepdir",
+            "--allow-unsafe-options",
         ],
     )
     asserts.predicate_from_cli(result, result.exit_code == 0)

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -229,7 +229,7 @@ def test_failed_init_vcs(monkeypatch, capsys):
     """
     pcs_path = os.getcwd()
 
-    def raiseexc(*_):
+    def raiseexc(*_, **__):
         raise GitCommandError("git", "pit")
 
     monkeypatch.setattr("git.repo.base.Repo.init", raiseexc)


### PR DESCRIPTION
A new GitPython version prohibits the use of unsafe options by default. The `perun init` command has hence been extended with a new option that allows the users to set this parameter.